### PR TITLE
Add a user_auth endpoint for Alpha.

### DIFF
--- a/ckanext/datagovuk/action/get.py
+++ b/ckanext/datagovuk/action/get.py
@@ -1,0 +1,65 @@
+import ckan.logic.schema
+from ckan.plugins.toolkit import (
+    abort,
+    check_access,
+    navl_validate,
+    ValidationError,
+    get_action,
+)
+import ckan.lib.dictization.model_save as model_save
+import ckan.lib.dictization.model_dictize as model_dictize
+
+from ckan.model import User
+
+
+log = __import__('logging').getLogger(__name__)
+
+
+# defined as they are in ckan/action/create.py to save further hacks to the
+# function copied from there
+_check_access = check_access
+_validate = navl_validate
+
+
+def user_auth(context, data_dict):
+    '''Authenticates a user
+
+    You must be a system administrator to authenticate users.
+
+    :param email: the email address of the user
+    :type email: string
+    :param password: the password of the user
+    :type password: string
+
+    :returns: the newly created user
+    :rtype: dictionary
+
+    '''
+    model = context['model']
+    session = context['session']
+
+    _check_access('user_auth', context, data_dict)
+
+    email = data_dict.get('email')
+    password = data_dict.get('password')
+
+    if not (email and password):
+        raise ValidationError(['email and password are both required'])
+
+    users = User.by_email(email)
+    user = users[0] if users else None
+
+    if (user is None) or \
+            (not user.is_active()) or \
+            (not user.validate_password(password)):
+        raise ValidationError(['There was a problem authenticating this user'])
+
+    user_dict = model_dictize.user_dictize(user, context)
+
+    ## Get the user's organisation list to return with the login details
+    fOrgList = get_action('organization_list_for_user')
+    user_dict['organisations'] = fOrgList(context, {'id': user.name})
+
+    # DGU Hack: added encoding so we don't barf on unicode user names
+    log.debug('Authenticated user {name}'.format(name=user.name.encode('utf8')))
+    return user_dict

--- a/ckanext/datagovuk/auth/__init__.py
+++ b/ckanext/datagovuk/auth/__init__.py
@@ -1,2 +1,3 @@
 
 from ckanext.datagovuk.auth.create import (group_create, organization_create)
+from ckanext.datagovuk.auth.get import (user_auth)

--- a/ckanext/datagovuk/auth/get.py
+++ b/ckanext/datagovuk/auth/get.py
@@ -1,0 +1,7 @@
+import ckan.plugins as plugins
+import ckan.plugins.toolkit as toolkit
+
+
+def user_auth(context, data_dict=None):
+    # sysadmins only
+    return {'success': False}

--- a/ckanext/datagovuk/plugin.py
+++ b/ckanext/datagovuk/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins.toolkit as toolkit
 import ckanext.datagovuk.auth as auth
 import ckanext.datagovuk.schema as schema_defs
 import ckanext.datagovuk.action.create
+import ckanext.datagovuk.action.get
 
 
 class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
@@ -22,7 +23,8 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     def get_auth_functions(self):
         return {
             'group_create': auth.group_create,
-            'organization_create': auth.organization_create
+            'organization_create': auth.organization_create,
+            'user_auth': auth.user_auth
         }
 
     # IDatasetForm
@@ -51,9 +53,10 @@ class DatagovukPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm):
     # IActions
 
     def get_actions(self):
-        actions = dict(
-            user_create=ckanext.datagovuk.action.create.user_create
-            )
-        return actions
+        return dict(
+            user_create=ckanext.datagovuk.action.create.user_create,
+            user_auth=ckanext.datagovuk.action.get.user_auth
+        )
+
 
     import ckanext.datagovuk.ckan_patches  # import does the monkey patching

--- a/ckanext/datagovuk/tests/test_user_auth.py
+++ b/ckanext/datagovuk/tests/test_user_auth.py
@@ -1,0 +1,80 @@
+"""Tests for user_auth API"""
+from nose.tools import assert_true, assert_false, assert_raises
+
+from ckan import model
+from ckan import logic
+from ckan.tests import factories, helpers
+
+
+class TestUserAuth:
+    @classmethod
+    def setup_class(cls):
+        helpers.reset_db()
+
+    def setup(self):
+        sysadmin = factories.Sysadmin()
+        self.context = {'model': model, 'user': sysadmin['name']}
+
+        user_dict = factories.User(email='hello@localhost')
+        self.user = model.User.get(user_dict['id'])
+        self.user.password = 'hello'
+        self.user.save()
+
+    def test_valid_call(self):
+        resp = helpers.call_action(
+            'user_auth',
+            self.context,
+            email=self.user.email,
+            password='hello'
+        )
+        assert resp['email'] == self.user.email, resp
+
+    def test_missing_email(self):
+        assert_raises(
+            logic.ValidationError,
+            helpers.call_action,
+            'user_auth',
+            self.context,
+            email='',
+            password='hello'
+        )
+
+    def test_missing_password(self):
+        assert_raises(
+            logic.ValidationError,
+            helpers.call_action,
+            'user_auth',
+            self.context,
+            email=self.user.email,
+            password=''
+        )
+
+    def test_bad_email(self):
+        assert_raises(
+            logic.ValidationError,
+            helpers.call_action,
+            'user_auth',
+            self.context,
+            email='not-correct@localhost',
+            password='hello'
+        )
+
+    def test_bad_password(self):
+        assert_raises(
+            logic.ValidationError,
+            helpers.call_action,
+            'user_auth',
+            self.context,
+            email=self.user.email,
+            password='goodbye'
+        )
+
+    def test_bad_username_and_password(self):
+        assert_raises(
+            logic.ValidationError,
+            helpers.call_action,
+            'user_auth',
+            self.context,
+            email='wrong',
+            password='password'
+        )


### PR DESCRIPTION
During Alpha we wish to be able to authenticate users without needing a
local model, and so here is an API endpoint, callable only by a sysadmin
which will return all of the user's detail on correct submission of
email and password.

The resulting dictionary also contains a list of the organisations that
the user is in.

One stumbling block is that we currently allow emails to be re-used by
different users.  For now we are just using the first such match, but
over time (as per #4) we need to resolve this (if any actually exist).